### PR TITLE
Remove MIX_ENV expectation and usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## v0.1.10 (2021-11-04)
+
+### Enhancements
+
+- **Breaking change** - Added `rewrite_db_url` config option. Removes reliance on ENV setting MIX_ENV.
+
+To use, in either `config/prod.exs` or `config/runtime.exs`, instruct the library to rewrite the `DATABASE_URL` used when connecting to the database. It takes into account which region is your primary region and attempts to connect to the primary or the replica accordingly.
+
+```elixir
+config :fly_postgres, rewrite_db_url: true
+```

--- a/README.md
+++ b/README.md
@@ -110,6 +110,25 @@ actual `Ecto.Repo`. Following the above example, it should point to
 
 With these project plumbing changes, you application code can stay largely untouched!
 
+### Production Config
+
+In either `config/prod.exs` or `config/runtime.exs`, instruct the library to
+rewrite the `DATABASE_URL` used when connecting to the database. This takes into
+account which region is your primary region and attempts to connect to the
+primary or the replica accordingly.
+
+```elixir
+config :fly_postgres, rewrite_db_url: true
+```
+
+Without this setting, the `DATABASE_URL` will be used as-is. In production, this
+means your app running in a distant region will open DB connections to the
+distant primary database. This results in very slow database queries!
+
+For `dev` and `test` environments, you don't need to set anything as `false` is
+the default setting. This means the library doesn't try to rewrite your
+`DATABASE_URL` for your local development environment, breaking your ability to
+connect to the database!
 ### Primary Region
 
 If your application is deployed to multiple Fly.io regions, the instances (or

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ For `dev` and `test` environments, you don't need to set anything as `false` is
 the default setting. This means the library doesn't try to rewrite your
 `DATABASE_URL` for your local development environment, breaking your ability to
 connect to the database!
+
 ### Primary Region
 
 If your application is deployed to multiple Fly.io regions, the instances (or

--- a/lib/fly_postgres.ex
+++ b/lib/fly_postgres.ex
@@ -50,8 +50,9 @@ defmodule Fly.Postgres do
       replica_url: replica_db_url()
     }
 
-    # Only check for non-primary DB URL in prod build
-    if System.get_env("MIX_ENV") == "prod" do
+    # Only rewrite the DB URL when configured to. Do this for prod build running
+    # on Fly
+    if Application.get_env(:fly_postgres, :rewrite_db_url, false) do
       do_database_url(data)
     else
       Logger.info("Using raw DATABASE_URL. Assumed DEV or TEST environment")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule FlyPostgres.MixProject do
   def project do
     [
       app: :fly_postgres,
-      version: "0.1.9",
+      version: "0.1.10",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       name: "Fly Postgres",


### PR DESCRIPTION
- Adds a config that you set in a `prod.exs` or `runtime.exs` file. 
- Adds a CHANGELOG file to track and explain changes
- Updated README with the breaking change.