### PR TITLE
Smarter polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,3 +258,19 @@ Fly.RPC.rpc_region(:primary, MyModule, :do_work, [arg1, arg2])
 ```
 
 This also works when modifying the database too.
+
+## LSN Polling
+
+The library polls the local database for what point in the replication process
+it has gotten to. It uses the LSN (Log Sequence Number) to determine that. Using
+this information, a process making changes against the primary database can
+request to be notified once the LSN it cares about has been replicated. This
+enables blocking operations that pause and wait for replication to complete.
+
+The active polling only happens once a process has requested to be notified.
+When there are no pending requests, there is no active polling. Also, there can
+be many active pending requests and still there will be only 1 polling process.
+So each waiting process isn't polling the database itself.
+
+The polling design scales well and doesn't perform work when there is nothing to
+track.

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,1 @@
+config :fly_postgres, :local_repo,

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,1 +1,0 @@
-config :fly_postgres, :local_repo,

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,9 @@ defmodule FlyPostgres.MixProject do
   def project do
     [
       app: :fly_postgres,
-      version: "0.1.10",
+      version: "0.1.11",
       elixir: "~> 1.12",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       name: "Fly Postgres",
       source_url: "https://github.com/superfly/fly_postgres_elixir",
@@ -22,6 +23,10 @@ defmodule FlyPostgres.MixProject do
       extra_applications: [:logger]
     ]
   end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/test/lsn/lsn_test.exs
+++ b/test/lsn/lsn_test.exs
@@ -1,9 +1,10 @@
 defmodule Fly.Postgres.LSNTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false  # uses FakeRepo
 
   doctest Fly.Postgres.LSN
 
   alias Fly.Postgres.LSN
+  alias Fly.Postgres.FakeRepo
 
   describe "new/2" do
     test "returns :not_replicating source when lsn is nil" do
@@ -51,6 +52,24 @@ defmodule Fly.Postgres.LSNTest do
       lsn_insert = %Fly.Postgres.LSN{fpart: 0, offset: 100_733_377, source: :insert}
       lsn_replay = %Fly.Postgres.LSN{fpart: 0, offset: 100_733_376, source: :replay}
       assert false == LSN.replicated?(lsn_replay, lsn_insert)
+    end
+  end
+
+  describe "current_wal_insert/1" do
+    test "returns correctly parsed LSN with :insert source" do
+      FakeRepo.set_insert_lsn(%Fly.Postgres.LSN{fpart: 0, offset: 100_700_300, source: :insert})
+      %LSN{source: :insert} = result = LSN.current_wal_insert(FakeRepo)
+      assert result.fpart == 0
+      assert result.offset == 100700300
+    end
+  end
+
+  describe "last_wal_replay/1" do
+    test "returns correctly parsed LSN with :replay source" do
+      FakeRepo.set_replay_lsn(%Fly.Postgres.LSN{fpart: 0, offset: 100_700_300, source: :replay})
+      %LSN{source: :replay} = result = LSN.last_wal_replay(FakeRepo)
+      assert result.fpart == 0
+      assert result.offset == 100700300
     end
   end
 end

--- a/test/lsn/lsn_tracker_test.exs
+++ b/test/lsn/lsn_tracker_test.exs
@@ -1,15 +1,22 @@
 defmodule Fly.Postgres.LSN.TrackerTest do
-  use ExUnit.Case, async: true
+  # Async false because uses the FakeRepo GenServer to mock out the repo
+  use ExUnit.Case, async: false
 
   doctest Fly.Postgres.LSN.Tracker
 
   alias Fly.Postgres.LSN
   alias Fly.Postgres.LSN.Tracker
+  alias Fly.Postgres.FakeRepo
 
   @test_lsn_table :test_lsn_cache
   @test_requests :test_lsn_requests
 
   setup do
+    insert_lsn = %Fly.Postgres.LSN{fpart: 0, offset: 2, source: :insert}
+    replay_lsn = %Fly.Postgres.LSN{fpart: 0, offset: 1, source: :replay}
+    FakeRepo.set_insert_lsn(insert_lsn)
+    FakeRepo.set_replay_lsn(replay_lsn)
+
     server =
       Tracker.start_link(
         name: :test_tracker,
@@ -17,17 +24,26 @@ defmodule Fly.Postgres.LSN.TrackerTest do
         requests_table_name: @test_requests
       )
 
-    # sleep for 5ms before running tests. Lets the server get started and create
+    # sleep for a few ms before running tests. Lets the server get started and create
     # the ETS table. Otherwise some race conditions exist where a test may run
     # before the ETS table is created.
-    # Process.sleep(5)
+    Process.sleep(50)
 
-    %{server: server}
+    %{server: server, insert_lsn: insert_lsn, replay_lsn: replay_lsn}
+  end
+
+  describe "initial query" do
+    test "starting new LSN.Tracker queries for initial replay LSN" do
+      %LSN{} = result = Tracker.get_last_replay(@test_lsn_table)
+      assert result.source == :replay
+      assert result.fpart == 0
+      assert result.offset == 1
+    end
   end
 
   describe "get_last_replay/1" do
-    test "returns nil when no entry exists" do
-      assert nil == Tracker.get_last_replay(@test_lsn_table)
+    test "returns initial queries replay value", %{replay_lsn: replay_lsn} do
+      assert replay_lsn == Tracker.get_last_replay(@test_lsn_table)
     end
 
     test "returns the stored LSN when found" do
@@ -84,34 +100,79 @@ defmodule Fly.Postgres.LSN.TrackerTest do
     end
   end
 
-  describe "process_request_entries/2" do
-    test "when no requests registered, does nothing" do
-      # first execution, no entries
-      replay = %LSN{fpart: 0, offset: 1, source: :replay}
-      assert :ok == Tracker.process_request_entries(replay, @test_requests)
+  describe "process_request_entries/1" do
+    setup do
+      %{
+        lsn_table: @test_lsn_table,
+        requests_table: @test_requests
+      }
+    end
+
+    test "when no requests registered, does nothing", state do
+      # first execution, report already replicated
+      assert :ok == Tracker.process_request_entries(state)
       refute_received {:lsn_replicated, _any}
     end
 
-    test "when a request is registered but it isn't replicated, nothing sent" do
+    test "when a request is registered but it isn't replicated, nothing sent", state do
       insert = %LSN{fpart: 0, offset: 100_733_376, source: :insert}
-      replay = %LSN{fpart: 0, offset: 1, source: :replay}
       Tracker.request_notification(@test_requests, insert)
-      assert :ok == Tracker.process_request_entries(replay, @test_requests)
+      assert :ok == Tracker.process_request_entries(state)
       refute_received {:lsn_replicated, _any}
       # Should still have ETS entry for request
       refute [] == :ets.match_object(@test_requests, {:"$1", :"$2"})
     end
 
-    test "when a request is registered and is replicated, receive notification" do
+    test "when a request is registered and is replicated, receive notification", state do
       insert = %LSN{fpart: 0, offset: 100_733_376, source: :insert}
       replay = %LSN{fpart: 0, offset: 100_733_376, source: :replay}
       Tracker.request_notification(@test_requests, insert)
+      FakeRepo.set_replay_lsn(replay)
 
-      assert :ok == Tracker.process_request_entries(replay, @test_requests)
+      assert :ok == Tracker.process_request_entries(state)
       msg = {:lsn_replicated, {self(), insert}}
       assert_received ^msg
       # the requests table should be empty now
       assert [] == :ets.match_object(@test_requests, {:"$1", :"$2"})
+    end
+  end
+
+  describe "polling" do
+    test "doesn't poll when no subscribers" do
+      initial_replay_count = FakeRepo.query_replay_count()
+      # sleep to wait and verify no queries are made
+      Process.sleep(350)
+      assert initial_replay_count == FakeRepo.query_replay_count()
+    end
+
+    test "polls when subscribers" do
+      initial_replay_count = FakeRepo.query_replay_count()
+      insert = %LSN{fpart: 0, offset: 100_733_376, source: :insert}
+      # test process subscribes
+      Tracker.request_notification(@test_requests, insert)
+      # sleep to wait and verify that queries are made
+      Process.sleep(350)
+      assert FakeRepo.query_replay_count() > initial_replay_count
+    end
+
+    test "notifies subscriber once replicated" do
+      initial_replay_count = FakeRepo.query_replay_count()
+      insert = %LSN{fpart: 0, offset: 100_700_300, source: :insert}
+      # test process subscribes
+      Tracker.request_notification(@test_requests, insert)
+
+      # Next query returns that it replicated
+      FakeRepo.set_replay_lsn(%Fly.Postgres.LSN{fpart: 0, offset: 100_700_300, source: :replay})
+      # wait to be notified replication completed. Should return success
+      assert :ready ==
+               Tracker.await_notification(%Fly.Postgres.LSN{
+                 fpart: 0,
+                 offset: 100_700_300,
+                 source: :insert
+               })
+
+      # Verify polling happened
+      assert FakeRepo.query_replay_count() > initial_replay_count
     end
   end
 end

--- a/test/support/fake_repo.ex
+++ b/test/support/fake_repo.ex
@@ -1,0 +1,11 @@
+defmodule FakeRepo do
+  # A Fake Ecto.Repo that returns desired fake responses for testing.
+
+  def query!("select CAST(pg_last_wal_replay_lsn() AS TEXT)") do
+
+  end
+
+  def query!("select CAST(pg_current_wal_insert_lsn() AS TEXT)") do
+
+  end
+end

--- a/test/support/fake_repo.ex
+++ b/test/support/fake_repo.ex
@@ -1,11 +1,100 @@
-defmodule FakeRepo do
+defmodule Fly.Postgres.FakeRepo do
   # A Fake Ecto.Repo that returns desired fake responses for testing.
+  use GenServer
+  alias __MODULE__
+  alias Fly.Postgres.LSN
+
+  @doc """
+  This creates a named GenServer. There can only be 1 running at a time.
+  Tests should be set as `async: false`.
+  """
+  def start_link do
+    GenServer.start_link(FakeRepo, nil, name: FakeRepo)
+  end
+
+  @impl true
+  def init(_) do
+    state = %{
+      replay_lsn: %LSN{fpart: 0, offset: 1},
+      insert_lsn: %LSN{fpart: 0, offset: 1},
+      # keep track of how many times the replay and insert numbers were requested
+      query_replay_count: 0,
+      query_insert_count: 0
+    }
+
+    {:ok, state}
+  end
+
+  def set_replay_lsn(%LSN{} = lsn) do
+    GenServer.call(FakeRepo, {:set_replay_lsn, lsn})
+  end
+
+  def set_insert_lsn(%LSN{} = lsn) do
+    GenServer.call(FakeRepo, {:set_insert_lsn, lsn})
+  end
 
   def query!("select CAST(pg_last_wal_replay_lsn() AS TEXT)") do
-
+    %LSN{} = lsn = GenServer.call(FakeRepo, :get_replay_lsn)
+    %Postgrex.Result{rows: [[lsn_to_text(lsn)]]}
   end
 
   def query!("select CAST(pg_current_wal_insert_lsn() AS TEXT)") do
+    %LSN{} = lsn = GenServer.call(FakeRepo, :get_insert_lsn)
+    %Postgrex.Result{rows: [[lsn_to_text(lsn)]]}
+  end
 
+  def query_replay_count do
+    GenServer.call(FakeRepo, :query_replay_count)
+  end
+
+  def query_insert_count do
+    GenServer.call(FakeRepo, :query_insert_count)
+  end
+
+  def reset_counts do
+    GenServer.call(FakeRepo, :reset_counts)
+  end
+
+  ##
+  ## SERVER
+  ##
+
+  @impl true
+  def handle_call(:reset_counts, _from, state) do
+    new_state =
+      state
+      |> Map.put(:query_replay_count, 0)
+      |> Map.put(:query_insert_count, 0)
+
+    {:reply, :ok, new_state}
+  end
+
+  def handle_call(:query_replay_count, _from, state) do
+    {:reply, state.query_replay_count, state}
+  end
+
+  def handle_call(:query_insert_count, _from, state) do
+    {:reply, state.query_insert_count, state}
+  end
+
+  def handle_call(:get_replay_lsn, _from, %{replay_lsn: lsn} = state) do
+    {:reply, lsn, Map.put(state, :query_replay_count, state.query_replay_count + 1)}
+  end
+
+  def handle_call(:get_insert_lsn, _from, %{insert_lsn: lsn} = state) do
+    {:reply, lsn, Map.put(state, :query_insert_count, state.query_replay_count + 1)}
+  end
+
+  def handle_call({:set_replay_lsn, lsn}, _from, state) do
+    {:reply, lsn, Map.put(state, :replay_lsn, lsn)}
+  end
+
+  def handle_call({:set_insert_lsn, lsn}, _from, state) do
+    {:reply, lsn, Map.put(state, :insert_lsn, lsn)}
+  end
+
+  # Convert an LSN struct back into a text string as it is returned from a query.
+  def lsn_to_text(%LSN{fpart: fpart, offset: offset}) do
+    Integer.to_string(fpart, 16) <> "/" <> Integer.to_string(offset, 16)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,6 @@
+ExUnit.configure(capture_log: true)
 ExUnit.start()
+# Start the FakeRepo GenServer
+{:ok, _pid} = Fly.Postgres.FakeRepo.start_link()
+# Set to use the FakeRepo
+Application.put_env(:fly_postgres, :local_repo, Fly.Postgres.FakeRepo)


### PR DESCRIPTION
- only poll the database when there are pending notification requests
- test tooling setup. Created a "FakeRepo" that is a GenServer that lets a test deal with that an Ecto Repo for the tests.