### PR TITLE
Improve dev/test usage of library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.12 (2021-11-16)
+
+- Fix: For dev and test environments, return `nil` for customized DATABASE_URL setting. This removes requirement for setting the DATABASE_URL in an ENV for local dev and test. Additionally, this fixes an issue where the dev database was being used when running tests.
+
 ## v0.1.11 (2021-11-06)
 
 - Enhancement: Internally, improved logic around polling the database for the replication status. Only polls when there is a request for replication notification.

--- a/README.md
+++ b/README.md
@@ -126,9 +126,7 @@ means your app running in a distant region will open DB connections to the
 distant primary database. This results in very slow database queries!
 
 For `dev` and `test` environments, you don't need to set anything as `false` is
-the default setting. This means the library doesn't try to rewrite your
-`DATABASE_URL` for your local development environment, breaking your ability to
-connect to the database!
+the default setting.
 
 ### Primary Region
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,30 @@ config :fly_postgres, :local_repo, MyApp.Repo.Local
 This helps the library to know which repo to use when talking to the database to
 ensure the needed replications have completed.
 
+In your `config/prod.exs`, add the following:
+
+```elixir
+# Instruct Fly.Postgres to operate in "prod" mode and do DB URL rewrites
+config :fly_postgres, :rewrite_db_url, true
+```
+
+### Releases and Migrations
+
+Assuming you are using a custom "Release" module like [this one in the HelloElixir](https://github.com/fly-apps/hello_elixir/blob/main/lib/hello_elixir/release.ex) demo project to execute your migrations in a special release task, then you need to explicitly load the `:fly_postgres` config so it will be available to connect to the database.
+
+The `load_app` function can be changed like this:
+
+```elixir
+  defp load_app do
+    Application.load(:fly_postgres)
+    Application.load(@app)
+  end
+```
+
+Once the configuration is loaded, the database migrations can be run as
+expected. Without this step, your deployment will fail when running migrations
+because the database connection settings will be wrong.
+
 ### Repo References
 
 The goal with using this repo wrapper, is to leave all of your application code

--- a/lib/fly_postgres.ex
+++ b/lib/fly_postgres.ex
@@ -42,6 +42,7 @@ defmodule Fly.Postgres do
   Compute the database url to use for this app given the current configuration
   and runtime environment.
   """
+  @spec database_url :: nil | String.t()
   def database_url do
     data = %{
       primary: Fly.primary_region(),
@@ -55,8 +56,7 @@ defmodule Fly.Postgres do
     if Application.get_env(:fly_postgres, :rewrite_db_url, false) do
       do_database_url(data)
     else
-      Logger.info("Using raw DATABASE_URL. Assumed DEV or TEST environment")
-      System.fetch_env!("DATABASE_URL")
+      Logger.debug("fly_postgres not configured to rewrite_db_url. Assumed DEV or TEST environment")
       nil
     end
   end

--- a/lib/fly_postgres.ex
+++ b/lib/fly_postgres.ex
@@ -8,10 +8,8 @@ defmodule Fly.Postgres do
 
   @doc false
   def rewrite_db_url? do
-    IO.puts "EXECUTE Fly.Postgres.rewrite_db_url?"
-    Logger.warn("FETCHING Fly.Postgres Application.get_env... WHAT'S GOING ON?? #{inspect(Application.get_env(:fly_postgres, :rewrite_db_url, false))}")
+    Logger.warn("FETCHING Fly.Postgres Application.get_env... WHAT'S GOING ON?? #{inspect(Application.get_env(:fly_postgres, :rewrite_db_url))}")
     Application.get_env(:fly_postgres, :rewrite_db_url, false)
-    true
   end
 
   @doc """

--- a/lib/fly_postgres.ex
+++ b/lib/fly_postgres.ex
@@ -6,6 +6,11 @@ defmodule Fly.Postgres do
   """
   require Logger
 
+  @doc false
+  def rewrite_db_url? do
+    Application.get_env(:fly_postgres, :rewrite_db_url) || false
+  end
+
   @doc """
   Return the database url used for connecting to the primary database. This is
   provided by the Fly.io platform when you have attached to a PostgreSQL
@@ -15,7 +20,7 @@ defmodule Fly.Postgres do
   """
   @spec primary_db_url :: nil | String.t() | no_return()
   def primary_db_url do
-    if Application.get_env(:fly_postgres, :rewrite_db_url, false) do
+    if rewrite_db_url?() do
       raw_url = System.fetch_env!("DATABASE_URL")
       primary = Fly.primary_region()
 
@@ -38,7 +43,7 @@ defmodule Fly.Postgres do
   """
   @spec replica_db_url :: nil | String.t() | no_return()
   def replica_db_url() do
-    if Application.get_env(:fly_postgres, :rewrite_db_url, false) do
+    if rewrite_db_url?() do
       raw_url = System.fetch_env!("DATABASE_URL")
       current = Fly.my_region()
 

--- a/lib/fly_postgres.ex
+++ b/lib/fly_postgres.ex
@@ -57,6 +57,7 @@ defmodule Fly.Postgres do
     else
       Logger.info("Using raw DATABASE_URL. Assumed DEV or TEST environment")
       System.fetch_env!("DATABASE_URL")
+      nil
     end
   end
 

--- a/lib/fly_postgres.ex
+++ b/lib/fly_postgres.ex
@@ -10,32 +10,46 @@ defmodule Fly.Postgres do
   Return the database url used for connecting to the primary database. This is
   provided by the Fly.io platform when you have attached to a PostgreSQL
   database. Stored as an ENV called `DATABASE_URL`.
-  """
-  def primary_db_url do
-    raw_url = System.fetch_env!("DATABASE_URL")
-    primary = Fly.primary_region()
 
-    # Be more explicit with the primary DB host name to specify the region.
-    # Otherwise DNS might direct it somewhere else.
-    uri = URI.parse(raw_url)
-    primary_uri = %URI{uri | host: "#{primary}.#{uri.host}"}
-    URI.to_string(primary_uri)
+  If `rewrite_db_url` is disabled, a `nil` is returned for the url.
+  """
+  @spec primary_db_url :: nil | String.t() | no_return()
+  def primary_db_url do
+    if Application.get_env(:fly_postgres, :rewrite_db_url, false) do
+      raw_url = System.fetch_env!("DATABASE_URL")
+      primary = Fly.primary_region()
+
+      # Be more explicit with the primary DB host name to specify the region.
+      # Otherwise DNS might direct it somewhere else.
+      uri = URI.parse(raw_url)
+      primary_uri = %URI{uri | host: "#{primary}.#{uri.host}"}
+      URI.to_string(primary_uri)
+    else
+      nil
+    end
   end
 
   @doc """
   Return a database url used for connecting to a replica database. This makes
   the assumption that there is a replica running in the region where the app
   instance is running.
-  """
-  def replica_db_url() do
-    raw_url = System.fetch_env!("DATABASE_URL")
-    current = Fly.my_region()
 
-    # Infer the replica URL. Assumed to be running in the region the app is
-    # deployed to.
-    uri = URI.parse(raw_url)
-    replica_uri = %URI{uri | host: "#{current}.#{uri.host}", port: 5433}
-    URI.to_string(replica_uri)
+  If `rewrite_db_url` is disabled, a `nil` is returned for the url.
+  """
+  @spec replica_db_url :: nil | String.t() | no_return()
+  def replica_db_url() do
+    if Application.get_env(:fly_postgres, :rewrite_db_url, false) do
+      raw_url = System.fetch_env!("DATABASE_URL")
+      current = Fly.my_region()
+
+      # Infer the replica URL. Assumed to be running in the region the app is
+      # deployed to.
+      uri = URI.parse(raw_url)
+      replica_uri = %URI{uri | host: "#{current}.#{uri.host}", port: 5433}
+      URI.to_string(replica_uri)
+    else
+      nil
+    end
   end
 
   @doc """
@@ -51,14 +65,7 @@ defmodule Fly.Postgres do
       replica_url: replica_db_url()
     }
 
-    # Only rewrite the DB URL when configured to. Do this for prod build running
-    # on Fly
-    if Application.get_env(:fly_postgres, :rewrite_db_url, false) do
-      do_database_url(data)
-    else
-      Logger.debug("fly_postgres not configured to rewrite_db_url. Assumed DEV or TEST environment")
-      nil
-    end
+    do_database_url(data)
   end
 
   defp do_database_url(%{primary: pri, current: curr} = data) when pri == curr do

--- a/lib/fly_postgres.ex
+++ b/lib/fly_postgres.ex
@@ -8,7 +8,6 @@ defmodule Fly.Postgres do
 
   @doc false
   def rewrite_db_url? do
-    Logger.warn("FETCHING Fly.Postgres Application.get_env... WHAT'S GOING ON?? #{inspect(Application.get_env(:fly_postgres, :rewrite_db_url))}")
     Application.get_env(:fly_postgres, :rewrite_db_url, false)
   end
 

--- a/lib/fly_postgres.ex
+++ b/lib/fly_postgres.ex
@@ -9,6 +9,7 @@ defmodule Fly.Postgres do
   @doc false
   def rewrite_db_url? do
     IO.puts "EXECUTE Fly.Postgres.rewrite_db_url?"
+    Logger.warn("FETCHING Fly.Postgres Application.get_env... WHAT'S GOING ON?? #{inspect(Application.get_env(:fly_postgres, :rewrite_db_url, false))}")
     Application.get_env(:fly_postgres, :rewrite_db_url, false)
   end
 

--- a/lib/fly_postgres.ex
+++ b/lib/fly_postgres.ex
@@ -8,6 +8,7 @@ defmodule Fly.Postgres do
 
   @doc false
   def rewrite_db_url? do
+    IO.puts "EXECUTE Fly.Postgres.rewrite_db_url?"
     Application.get_env(:fly_postgres, :rewrite_db_url) || false
   end
 

--- a/lib/fly_postgres.ex
+++ b/lib/fly_postgres.ex
@@ -9,7 +9,7 @@ defmodule Fly.Postgres do
   @doc false
   def rewrite_db_url? do
     IO.puts "EXECUTE Fly.Postgres.rewrite_db_url?"
-    Application.get_env(:fly_postgres, :rewrite_db_url) || false
+    Application.get_env(:fly_postgres, :rewrite_db_url, false)
   end
 
   @doc """

--- a/lib/fly_postgres.ex
+++ b/lib/fly_postgres.ex
@@ -11,6 +11,7 @@ defmodule Fly.Postgres do
     IO.puts "EXECUTE Fly.Postgres.rewrite_db_url?"
     Logger.warn("FETCHING Fly.Postgres Application.get_env... WHAT'S GOING ON?? #{inspect(Application.get_env(:fly_postgres, :rewrite_db_url, false))}")
     Application.get_env(:fly_postgres, :rewrite_db_url, false)
+    true
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule FlyPostgres.MixProject do
   def project do
     [
       app: :fly_postgres,
-      version: "0.1.11",
+      version: "0.1.12",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/fly_postgres_test.exs
+++ b/test/fly_postgres_test.exs
@@ -13,6 +13,8 @@ defmodule Fly.PostgresTest do
        "postgres://some-user:some-pass@my-app-db.internal:5432/some_app?sslmode=disable"}
     ])
 
+    Application.put_env(:fly_postgres, :rewrite_db_url, true)
+
     %{}
   end
 


### PR DESCRIPTION
- Fix for dev and test environments, returns `nil` for customized DATABASE_URL setting. No longer requires local dev to set DATABASE_URL ENV
- Explicitly enable DB URL rewriting for PROD builds
- Updates documentation
- New release