### PR TITLE
use DNS for nearest replica DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Improvement: Use new Fly.io internal DNS feature to connect to the "nearest" replica database when deployed to a region other than the primary region.
 
+Solves a problem when an instance is deployed to a backup region where the replica isn't deployed. Also helps make more resilient in going to closest replica it can find should any other problems prevent the expected one to be available.
+
 ## v0.1.12 (2021-11-16)
 
 - Fix: For dev and test environments, return `nil` for customized DATABASE_URL setting. This removes requirement for setting the DATABASE_URL in an ENV for local dev and test. Additionally, this fixes an issue where the dev database was being used when running tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.13 (2021-12-28)
+
+- Improvement: Use new Fly.io internal DNS feature to connect to the "nearest" replica database when deployed to a region other than the primary region.
+
 ## v0.1.12 (2021-11-16)
 
 - Fix: For dev and test environments, return `nil` for customized DATABASE_URL setting. This removes requirement for setting the DATABASE_URL in an ENV for local dev and test. Additionally, this fixes an issue where the dev database was being used when running tests.

--- a/lib/fly_postgres.ex
+++ b/lib/fly_postgres.ex
@@ -45,12 +45,11 @@ defmodule Fly.Postgres do
   def replica_db_url() do
     if rewrite_db_url?() do
       raw_url = System.fetch_env!("DATABASE_URL")
-      current = Fly.my_region()
 
       # Infer the replica URL. Assumed to be running in the region the app is
       # deployed to.
       uri = URI.parse(raw_url)
-      replica_uri = %URI{uri | host: "#{current}.#{uri.host}", port: 5433}
+      replica_uri = %URI{uri | host: "top1.nearest.of.#{uri.host}", port: 5433}
       URI.to_string(replica_uri)
     else
       nil

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule FlyPostgres.MixProject do
   def project do
     [
       app: :fly_postgres,
-      version: "0.1.12",
+      version: "0.1.13",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/fly_postgres_test.exs
+++ b/test/fly_postgres_test.exs
@@ -36,7 +36,7 @@ defmodule Fly.PostgresTest do
 
     test "includes current FLY_REGION in host name" do
       result = Fly.Postgres.replica_db_url()
-      assert String.contains?(result, "@abc.my-app-db.internal")
+      assert String.contains?(result, "@top1.nearest.of.my-app-db.internal")
     end
   end
 end


### PR DESCRIPTION
- makes more resilient
- doesn't fail if temporarily deployed to a backup region that doesn't the database

This is pretty much an invisible change. This also bumps the version.