### PR TITLE
fixed forget to pass replication_timeout or tracker params

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ After changing your repo name, generating migrations can end up in the wrong pla
 
 You can override the inferred location in your config:
 
-```
+```elixir
 config :my_app, MyApp.Repo.Local,
   priv: "priv/repo"
 ```
@@ -240,7 +240,7 @@ MyApp.Repo.delete(item, await: false)
 
 When business logic code makes a number of changes or does some back and forth
 with the database, the "Automatic Usage" will be too slow. An example is looping
-though a list and performing a database insert on each iteration. Waiting for
+through a list and performing a database insert on each iteration. Waiting for
 the insert to complete and be locally replicated before performing the next
 iteration could be very slow.
 

--- a/lib/lsn/lsn_tracker.ex
+++ b/lib/lsn/lsn_tracker.ex
@@ -150,7 +150,7 @@ defmodule Fly.Postgres.LSN.Tracker do
       #
       # NOTE: This does add a slight delay to RPC calls using LSN. Waits for the
       # GenServer to run the check for the DB.
-      if replicated?(lsn) do
+      if replicated?(lsn, opts) do
         :ready
       else
         verbose_log(:info, fn ->

--- a/lib/lsn/lsn_tracker.ex
+++ b/lib/lsn/lsn_tracker.ex
@@ -27,6 +27,7 @@ defmodule Fly.Postgres.LSN.Tracker do
     if !Keyword.has_key?(opts, :repo) do
       raise ArgumentError, ":repo must be given when starting the LSN Tracker"
     end
+
     name = Keyword.get(opts, :name, __MODULE__)
     GenServer.start_link(__MODULE__, Keyword.put(opts, :name, name), name: name)
   end
@@ -298,6 +299,9 @@ defmodule Fly.Postgres.LSN.Tracker do
 
   def get_table_name(base_table_name, opts \\ []) do
     tracker_name = Keyword.get(opts, :tracker) || __MODULE__
-    Keyword.get_lazy(opts, :override_table_name, fn -> tracker_table_name(base_table_name, tracker_name) end)
+
+    Keyword.get_lazy(opts, :override_table_name, fn ->
+      tracker_table_name(base_table_name, tracker_name)
+    end)
   end
 end

--- a/lib/repo.ex
+++ b/lib/repo.ex
@@ -182,11 +182,15 @@ defmodule Fly.Repo do
       See `Ecto.Repo.insert_all/3` for full documentation.
       """
       def insert_all(schema_or_source, entries_or_query, opts \\ []) do
-        unquote(__MODULE__).__exec_on_primary__(:insert_all, [
-          schema_or_source,
-          entries_or_query,
+        unquote(__MODULE__).__exec_on_primary__(
+          :insert_all,
+          [
+            schema_or_source,
+            entries_or_query,
+            opts
+          ],
           opts
-        ], opts)
+        )
       end
 
       @doc """

--- a/test/lsn/lsn_test.exs
+++ b/test/lsn/lsn_test.exs
@@ -1,5 +1,6 @@
 defmodule Fly.Postgres.LSNTest do
-  use ExUnit.Case, async: false  # uses FakeRepo
+  # uses FakeRepo
+  use ExUnit.Case, async: false
 
   doctest Fly.Postgres.LSN
 
@@ -60,7 +61,7 @@ defmodule Fly.Postgres.LSNTest do
       FakeRepo.set_insert_lsn(%Fly.Postgres.LSN{fpart: 0, offset: 100_700_300, source: :insert})
       %LSN{source: :insert} = result = LSN.current_wal_insert(FakeRepo)
       assert result.fpart == 0
-      assert result.offset == 100700300
+      assert result.offset == 100_700_300
     end
   end
 
@@ -69,7 +70,7 @@ defmodule Fly.Postgres.LSNTest do
       FakeRepo.set_replay_lsn(%Fly.Postgres.LSN{fpart: 0, offset: 100_700_300, source: :replay})
       %LSN{source: :replay} = result = LSN.last_wal_replay(FakeRepo)
       assert result.fpart == 0
-      assert result.offset == 100700300
+      assert result.offset == 100_700_300
     end
   end
 end

--- a/test/lsn/lsn_tracker_test.exs
+++ b/test/lsn/lsn_tracker_test.exs
@@ -37,7 +37,10 @@ defmodule Fly.Postgres.LSN.TrackerTest do
 
   describe "initial query" do
     test "starting new LSN.Tracker queries for initial replay LSN", %{state: state} do
-      %LSN{} = result = Tracker.get_last_replay(tracker: state.tracker_name, override_table_name: state.lsn_table)
+      %LSN{} =
+        result =
+        Tracker.get_last_replay(tracker: state.tracker_name, override_table_name: state.lsn_table)
+
       assert result.source == :replay
       assert result.fpart == 0
       assert result.offset == 1
@@ -46,19 +49,29 @@ defmodule Fly.Postgres.LSN.TrackerTest do
 
   describe "get_repo/1" do
     test "returns the repo module used by the tracker", %{state: state} do
-      assert FakeRepo == Tracker.get_repo(tracker: state.tracker_name, override_table_name: state.lsn_table)
+      assert FakeRepo ==
+               Tracker.get_repo(tracker: state.tracker_name, override_table_name: state.lsn_table)
     end
   end
 
   describe "get_last_replay/1" do
     test "returns initial queries replay value", %{replay_lsn: replay_lsn, state: state} do
-      assert replay_lsn == Tracker.get_last_replay(tracker: state.tracker_name, override_table_name: state.lsn_table)
+      assert replay_lsn ==
+               Tracker.get_last_replay(
+                 tracker: state.tracker_name,
+                 override_table_name: state.lsn_table
+               )
     end
 
     test "returns the stored LSN when found", %{state: state} do
       replay = %LSN{fpart: 0, offset: 100_733_376, source: :replay}
       Tracker.put_lsn(replay, state)
-      assert replay == Tracker.get_last_replay(override_table_name: state.lsn_table, tracker: state.tracker_name)
+
+      assert replay ==
+               Tracker.get_last_replay(
+                 override_table_name: state.lsn_table,
+                 tracker: state.tracker_name
+               )
     end
   end
 
@@ -67,19 +80,34 @@ defmodule Fly.Postgres.LSN.TrackerTest do
       lsn = %LSN{fpart: 0, offset: 100_733_376, source: :insert}
       replay = %LSN{fpart: 0, offset: 100_733_376, source: :replay}
       Tracker.put_lsn(replay, state)
-      assert true == Tracker.replicated?(lsn, override_table_name: state.lsn_table, tracker: state.tracker_name)
+
+      assert true ==
+               Tracker.replicated?(lsn,
+                 override_table_name: state.lsn_table,
+                 tracker: state.tracker_name
+               )
     end
 
     test "returns false when the replay entry is not present", %{state: state} do
       lsn = %LSN{fpart: 0, offset: 100_733_376, source: :insert}
-      assert false == Tracker.replicated?(lsn, override_table_name: state.lsn_table, tracker: state.tracker_name)
+
+      assert false ==
+               Tracker.replicated?(lsn,
+                 override_table_name: state.lsn_table,
+                 tracker: state.tracker_name
+               )
     end
 
     test "returns false when a matching entry is not YET present", %{state: state} do
       lsn = %LSN{fpart: 0, offset: 200_000_000, source: :insert}
       replay = %LSN{fpart: 0, offset: 100_733_376, source: :replay}
       Tracker.put_lsn(replay, state)
-      assert false == Tracker.replicated?(lsn, override_table_name: state.lsn_table, tracker: state.tracker_name)
+
+      assert false ==
+               Tracker.replicated?(lsn,
+                 override_table_name: state.lsn_table,
+                 tracker: state.tracker_name
+               )
     end
   end
 


### PR DESCRIPTION
I see the new version (0.2.0) can specify `replication_timeout`, but the following scenarios are not available:

```elixir
defmodule MyApp.Repo do
  use Fly.Repo, local_repo: MyApp.Repo.Local, replication_timeout: 5_000
end
# or
MyApp.Repo.insert(changeset, replication_timeout: 5_000)
```

Hope the solution is correct, and I ran `mix format`.