### PR TITLE
Only rewrite DB URLs in prod builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ directly on the local replica. Other modifying functions like `insert`,
 calls to a node in your Elixir cluster running in the primary region. That
 ability is provided by the `fly_rpc` library.
 
-The `Mix.env()` is passed in to let `fly_postgres` know about your project's
-build environment. `Fly.Postgres` only attempts to rewrite the database URL when
-your app is running in `:prod` mode. When running in `:dev` or `:test`, no
-`Ecto.Repo` configuration changes are made.
+The value of the `Mix.env()` is set at build time to `@env` and passed in to let
+`fly_postgres` know about the project's build environment. `Fly.Postgres` only
+attempts to rewrite the database URL when your app is running in `:prod` mode.
+When running in `:dev` or `:test`, no `Ecto.Repo` configuration changes are
+made.
 
 ### Migration Files
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ defmodule MyApp.Repo.Local do
     otp_app: :my_app,
     adapter: Ecto.Adapters.Postgres
 
-  # Dynamically configure the database url based on runtime and build environment.
+  @env Mix.env()
+
+  # Dynamically configure the database url based on runtime and build
+  # environments.
   def init(_type, config) do
-    Fly.Postgres.config_repo_url(config, Mix.env())
+    Fly.Postgres.config_repo_url(config, @env)
   end
 end
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ defmodule MyApp.Repo.Local do
     otp_app: :my_app,
     adapter: Ecto.Adapters.Postgres
 
-  # Dynamically configure the database url based on runtime environment.
+  # Dynamically configure the database url based on runtime and build environment.
   def init(_type, config) do
-    Fly.Postgres.config_repo_url(config)
+    Fly.Postgres.config_repo_url(config, Mix.env())
   end
 end
 
@@ -79,6 +79,11 @@ directly on the local replica. Other modifying functions like `insert`,
 `update`, and `delete` are performed on the **primary database** through proxy
 calls to a node in your Elixir cluster running in the primary region. That
 ability is provided by the `fly_rpc` library.
+
+The `Mix.env()` is passed in to let `fly_postgres` know about your project's
+build environment. `Fly.Postgres` only attempts to rewrite the database URL when
+your app is running in `:prod` mode. When running in `:dev` or `:test`, no
+`Ecto.Repo` configuration changes are made.
 
 ### Migration Files
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule FlyPostgres.MixProject do
   def project do
     [
       app: :fly_postgres,
-      version: "0.2.3",
+      version: "0.2.4",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This creates a breaking change. `Fly.Postgres.config_repo_url/1` is changed to `Fly.Postgres.config_repo_url/2`.

An app that upgrades to this version will fail to compile until an additional change is made. The README is updated to reflect the config. 

## Fixes

closes #21 

## Update

When setting up the wrapped repo, use the following config instead.

```elixir
defmodule MyApp.Repo.Local do
  use Ecto.Repo,
    otp_app: :my_app,
    adapter: Ecto.Adapters.Postgres

  @env Mix.env()

  # Dynamically configure the database url based on runtime and build
  # environments.
  def init(_type, config) do
    Fly.Postgres.config_repo_url(config, @env)
  end
end

defmodule MyApp.Repo do
  use Fly.Repo, local_repo: MyApp.Repo.Local
end
```

This stores the build environment and passes that into the `Fly.Postgres.config_repo_url/2` function. The function changed to not attempt any URL rewriting when in `:dev` or `:test` modes. It only looks to change the URL when in `:prod` mode.

Further, an error is raised if the `:url` is missing from the `Ecto.Repo` config. 

## Explanation

Previously, `fly_postgres` looked for the presence of a database `:url` config to infer if it was running in production and should attempt to rewrite the Host URL or not. The default database config uses split out keys like this:

```elixir
config :my_app, MyApp.Repo.Local,
  username: "postgres",
  password: "postgres",
  database: "my_app_dev",
  hostname: "localhost"
```

Fly sets the `DATABASE_URL` `ENV` which is used in prod to specify the full database connection settings in a url.

For project who use a full DB URL in `dev` and/or `test`, the library wrongly assumed it was running in a `prod` environment.

This change addresses this by making the build environment explicit.