### PR TITLE
Execute transaction + rollback on primary.

### DIFF
--- a/lib/repo.ex
+++ b/lib/repo.ex
@@ -323,7 +323,7 @@ defmodule Fly.Repo do
       See `Ecto.Repo.rollback/1` for full documentation.
       """
       def rollback(value) do
-        unquote(__MODULE__).__exec_local__(:rollback, [value])
+        unquote(__MODULE__).__exec_on_primary__(:rollback, [value])
       end
 
       @doc """

--- a/lib/repo.ex
+++ b/lib/repo.ex
@@ -344,7 +344,7 @@ defmodule Fly.Repo do
       See `Ecto.Repo.transaction/2` for full documentation.
       """
       def transaction(fun_or_multi, opts \\ []) do
-        unquote(__MODULE__).__exec_local__(:transaction, [fun_or_multi, opts])
+        unquote(__MODULE__).__exec_on_primary__(:transaction, [fun_or_multi, opts])
       end
 
       @doc """

--- a/lib/repo.ex
+++ b/lib/repo.ex
@@ -332,8 +332,8 @@ defmodule Fly.Repo do
 
       See `Ecto.Repo.rollback/1` for full documentation.
       """
-      def rollback(value) do
-        unquote(__MODULE__).__exec_on_primary__(:rollback, [value])
+      def rollback(value, opts \\ []) do
+        unquote(__MODULE__).__exec_on_primary__(:rollback, [value], opts)
       end
 
       @doc """
@@ -354,7 +354,7 @@ defmodule Fly.Repo do
       See `Ecto.Repo.transaction/2` for full documentation.
       """
       def transaction(fun_or_multi, opts \\ []) do
-        unquote(__MODULE__).__exec_on_primary__(:transaction, [fun_or_multi, opts])
+        unquote(__MODULE__).__exec_on_primary__(:transaction, [fun_or_multi], opts)
       end
 
       @doc """

--- a/lib/repo.ex
+++ b/lib/repo.ex
@@ -230,6 +230,16 @@ defmodule Fly.Repo do
       end
 
       @doc """
+      Loads data into a schema or a map.
+
+      See `Ecto.Repo.load/2` for full documentation.
+
+      """
+      def load(schema_or_map, data) do
+        unquote(__MODULE__).__exec_local__(:load, [schema_or_map, data])
+      end
+
+      @doc """
       Fetches a single result from the query.
 
       See `Ecto.Repo.one/2` for full documentation.


### PR DESCRIPTION
# Description

Documentation for the `Fly.Repo.transaction` + `Fly.Repo.rollback` functions reference that they will be executed on the primary instance due to transactions being used to modify data, yet `__exec_local__` is actually called internally when the function is invoked. 

> `Fly.Repo.transaction/2` documentation
```
 Runs the given function or Ecto.Multi inside a transaction.

      This defaults to the primary (writable) repo as it is assumed this is being
      used for data modification. Override to operate on the replica.

      See `Ecto.Repo.transaction/2` for full documentation.
```

This PR modifies these functions to call `__exec_on_primary__` instead to align the described functionality with the actual behavior.

Also the `Repo.load/2` function is added to the module. This function exists on `Ecto.Repo` and serves to map between structs + sets of columnar data. This doesn't actually hit the database so uses `__exec_local__` to forward to whatever repo is being used.

