### PR TITLE
Support flycast db urls

### DIFF
--- a/lib/fly_postgres.ex
+++ b/lib/fly_postgres.ex
@@ -58,7 +58,7 @@ defmodule Fly.Postgres do
       String.contains?(uri.host, ".flycast") ->
         config
 
-        # If already using `top1.nearest.of.` then don't modify it
+      # If already using `top1.nearest.of.` then don't modify it
       String.contains?(uri.host, "top1.nearest.of.") ->
         config
 

--- a/lib/fly_postgres.ex
+++ b/lib/fly_postgres.ex
@@ -54,7 +54,11 @@ defmodule Fly.Postgres do
 
     # if detected DNS helpers in the URI, return unchanged
     cond do
-      # If already using `top1.nearest.of.` then don't modify it
+      # If using .flycast don't modify
+      String.contains?(uri.host, ".flycast") ->
+        config
+
+        # If already using `top1.nearest.of.` then don't modify it
       String.contains?(uri.host, "top1.nearest.of.") ->
         config
 

--- a/test/fly_postgres_test.exs
+++ b/test/fly_postgres_test.exs
@@ -9,6 +9,7 @@ defmodule Fly.PostgresTest do
 
   @url_dns "postgres://some-user:some-pass@top1.nearest.of.my-app-db.internal:5432/some_app"
   @url_base "postgres://some-user:some-pass@my-app-db.internal:5432/some_app"
+  @url_flycast "postgres://some-user:some-pass@my-app-db.flycast:5432/some_app"
 
   setup do
     System.put_env([{"FLY_REGION", "abc"}, {"PRIMARY_REGION", "xyz"}, {"DATABASE_URL", @url_dns}])
@@ -19,6 +20,12 @@ defmodule Fly.PostgresTest do
   describe "rewrite_database_url!/1" do
     test "returns config unchanged when in primary region and includes DNS helper parts" do
       System.put_env([{"FLY_REGION", "xyz"}])
+      config = [stuff: "THINGS", url: System.get_env("DATABASE_URL")]
+      assert config == Fly.Postgres.rewrite_database_url!(config)
+    end
+
+    test "returns config unchanged when using flycast" do
+      System.put_env([{"FLY_REGION", "xyz"}, {"DATABASE_URL", @url_flycast}])
       config = [stuff: "THINGS", url: System.get_env("DATABASE_URL")]
       assert config == Fly.Postgres.rewrite_database_url!(config)
     end


### PR DESCRIPTION
We launched flycast for pg clusters earlier this year: https://community.fly.io/t/flycast-for-postgres/10628

Now DATABASE_URLs that use flycast will have the form: `postgres://user:pass@app-name.flycast:5432/db_name`. Before this change the host was rewritten to `top1.nearest.of.app-name.flycast`, which is not valid and would result in failed connections.

With this change we do not modify hostname when a flycast hostname is used.
